### PR TITLE
Improved Save Canvas Logic

### DIFF
--- a/GStain/out/production/Paint Project/main/main.fxml
+++ b/GStain/out/production/Paint Project/main/main.fxml
@@ -1,4 +1,3 @@
-<?import javafx.geometry.Insets?>
 <?import javafx.scene.layout.GridPane?>
 
 <?import javafx.scene.control.Button?>
@@ -14,8 +13,8 @@
 <?import javafx.scene.control.ColorPicker?>
 <?import javafx.scene.control.Separator?>
 <?import javafx.scene.control.ScrollPane?>
-<?import javafx.scene.chart.NumberAxis?>
 <?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.StackPane?>
 <GridPane fx:controller="main.Controller" fx:id="MainWindow"
           xmlns:fx="src/main/main.fxml" styleClass="body">
     <!-- Main Menu -->
@@ -54,7 +53,7 @@
         <ColorPicker fx:id="BorderColorPicker" onAction="#handleBorderColorPicked"/>
         <Label text="Stroke:" styleClass="stroke-label" />
         <TextField onKeyTyped="#handleStrokeChange" fx:id="Stroke" prefWidth="80"  />
-        <Label fx:id="ShapeLabel" text="Shape:" styleClass="stroke-label" />
+        <Label text="Shape:" styleClass="stroke-label" />
         <TextField onKeyTyped="#handleWidthChange" fx:id="ShapeWidth" prefWidth="80"  />
         <TextField onKeyTyped="#handleHeightChange" fx:id="ShapeHeight" prefWidth="80"  />
     </HBox>
@@ -88,6 +87,7 @@
         <ScrollPane fx:id="CanvasArea" HBox.hgrow="ALWAYS" hbarPolicy="ALWAYS" vbarPolicy="ALWAYS" fitToHeight="true"
                     fitToWidth="true"
                     styleClass="CanvasArea">
+            <StackPane fx:id="CanvasHolder" />
         </ScrollPane>
     </HBox>
     <HBox GridPane.columnIndex="0" GridPane.rowIndex="3" fx:id="MonitorArea" styleClass="monitor-text" >

--- a/GStain/src/main/CommandSender.java
+++ b/GStain/src/main/CommandSender.java
@@ -14,6 +14,10 @@ public class CommandSender {
         commands = new ArrayList<>();
     }
 
+    public ArrayList<Command> getCommands() {
+        return commands;
+    }
+
     /**
      * Cleans List before pointer reset to remove unreachable commands
      */

--- a/GStain/src/main/dialogs/CanvasInitDialog.java
+++ b/GStain/src/main/dialogs/CanvasInitDialog.java
@@ -87,54 +87,13 @@ public class CanvasInitDialog {
             if (dialogButton == confirmBtnType) {
                 if (!titleField.getText().matches("[A-Za-z0-9_ÄäËëÖöÏïÜüÿÂâÊêÔôÎîÛûÁáÉéÓóÍíÚúÝýÀàÈèÒòÌìÙù!@#$^&()+={} ]+") || !widthField.getText().matches("[0-9]+") || !heightField.getText().matches("[0-9]+")) return null;
 
-                // Define Canvas
-                Canvas canvas = model.getCanvas();
+                model.createCanvas(titleField.getText(), Double.parseDouble(widthField.getText()), Double.parseDouble(heightField.getText()));
 
-                // Configure Canvas
-                canvas.setName(titleField.getText());
-                model.setStageTitle(canvas.getName());
-                configureCanvasEventHandlers(canvas, model);
-                parent.getChildren().add(canvas);
-
-                // Define size of Canvas
-                canvas.setMinSize(Double.parseDouble(widthField.getText()), Double.parseDouble(heightField.getText()));
-                canvas.setMaxSize(Double.parseDouble(widthField.getText()), Double.parseDouble(heightField.getText()));
-
-                // Canvas Styling
-                canvas.setStyle("-fx-background-color: #ffffff");
-
-                model.getToolModel().setTool(ToolType.POINTER);
                 dialog.close();
             }
             return null;
         });
 
         dialog.showAndWait();
-    }
-
-    private void configureCanvasEventHandlers(Canvas canvas, Model model) {
-        /*
-            SELECTION RULES:
-
-            Selection is based on hierarchy, first element in group has priority
-
-            When shift is being hold
-                - Elements which are selected and clicked on will be deselected
-                - Elements which are selected and NOT clicked on will stay selected
-
-            When shift is NOT being hold:
-                - All elements which are not clicked on will be deselected
-        */
-        // Handle Mouse Pressed Event
-        MousePressedOnCanvasEventHandler mousePressedOnCanvasEventHandler = new MousePressedOnCanvasEventHandler(model);
-        canvas.setOnMousePressed(mousePressedOnCanvasEventHandler);
-
-        // Handle Mouse Dragged Event
-        MouseDraggedOnCanvasEventHandler mouseDraggedOnCanvasEventHandler = new MouseDraggedOnCanvasEventHandler(model);
-        canvas.setOnMouseDragged(mouseDraggedOnCanvasEventHandler);
-
-        // Handle Mouse Released Event
-        MouseReleasedOnCanvasEventHandler mouseReleasedOnCanvasEventHandler = new MouseReleasedOnCanvasEventHandler(model);
-        canvas.setOnMouseReleased(mouseReleasedOnCanvasEventHandler);
     }
 }

--- a/GStain/src/main/dialogs/SaveBeforeClosingDialog.java
+++ b/GStain/src/main/dialogs/SaveBeforeClosingDialog.java
@@ -1,8 +1,8 @@
 package main.dialogs;
 
+import javafx.event.Event;
 import javafx.scene.control.*;
 import javafx.scene.layout.Pane;
-import javafx.util.Pair;
 import main.models.Model;
 
 public class SaveBeforeClosingDialog {
@@ -35,13 +35,15 @@ public class SaveBeforeClosingDialog {
             }
 
             // Remove Canvas
-            CanvasParent.getChildren().remove(model.getCanvas());
             model.closeCanvas();
 
             alert.close();
             if (promptNew) {
                 // Create new Canvas
                 new CanvasInitDialog(model, CanvasParent).showDialog();
+            }
+            else {
+                model.getStage().close();
             }
         });
     }

--- a/GStain/src/main/main.fxml
+++ b/GStain/src/main/main.fxml
@@ -1,4 +1,3 @@
-<?import javafx.geometry.Insets?>
 <?import javafx.scene.layout.GridPane?>
 
 <?import javafx.scene.control.Button?>
@@ -14,8 +13,8 @@
 <?import javafx.scene.control.ColorPicker?>
 <?import javafx.scene.control.Separator?>
 <?import javafx.scene.control.ScrollPane?>
-<?import javafx.scene.chart.NumberAxis?>
 <?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.StackPane?>
 <GridPane fx:controller="main.Controller" fx:id="MainWindow"
           xmlns:fx="src/main/main.fxml" styleClass="body">
     <!-- Main Menu -->
@@ -54,7 +53,7 @@
         <ColorPicker fx:id="BorderColorPicker" onAction="#handleBorderColorPicked"/>
         <Label text="Stroke:" styleClass="stroke-label" />
         <TextField onKeyTyped="#handleStrokeChange" fx:id="Stroke" prefWidth="80"  />
-        <Label fx:id="ShapeLabel" text="Shape:" styleClass="stroke-label" />
+        <Label text="Shape:" styleClass="stroke-label" />
         <TextField onKeyTyped="#handleWidthChange" fx:id="ShapeWidth" prefWidth="80"  />
         <TextField onKeyTyped="#handleHeightChange" fx:id="ShapeHeight" prefWidth="80"  />
     </HBox>
@@ -88,6 +87,7 @@
         <ScrollPane fx:id="CanvasArea" HBox.hgrow="ALWAYS" hbarPolicy="ALWAYS" vbarPolicy="ALWAYS" fitToHeight="true"
                     fitToWidth="true"
                     styleClass="CanvasArea">
+            <StackPane fx:id="CanvasHolder" />
         </ScrollPane>
     </HBox>
     <HBox GridPane.columnIndex="0" GridPane.rowIndex="3" fx:id="MonitorArea" styleClass="monitor-text" >


### PR DESCRIPTION
main.fxml:
- CanvasHolder is now available when Controller constructor has been called instead of having to be set to CanvasArea

CommandSender:
- Gave ArrayList<Command> commands a getter

Controller:
- Handled on window close for prompt to save unsaved changes

CanvasInitDialog:
- Removed canvas remove, save and create logic (will now be handled by model)

SaveBeforeClosingDialog:
- Added stage closing

Model:
- Added CanvasHolder to constructor
- Added method createCanvas (takes title, width and height), creates canvas and adds it to the CanvasHolder StackPane
- Added method configureCanvasEventHandlers, ported from CanvasInitDialog
- Added the removal of the GUI element in closeCanvas
- Added method unsavedChanges, defines the logic the state of the application has to fullfill and returns false if there are no changes made and true if there are changes made.
This logic should be improved further down the line